### PR TITLE
Doc update and simple fixes

### DIFF
--- a/README_v2.md
+++ b/README_v2.md
@@ -264,9 +264,9 @@ ansible-playbook -i inventory/ playbooks/configure_instances.yml
 ```
 
 Contrail installation:
-orchestrator can be openstack (installs kolla) or none (for pure k8s installations)    .   
+orchestrator can be openstack (installs kolla) or kubernetes (for pure k8s installations)    .   
 ```
-ansible-playbook -e orchestrator=none|openstack -i inventory/ playbooks/install_contrail.yml
+ansible-playbook -e orchestrator=kubernetes|openstack -i inventory/ playbooks/install_contrail.yml
 ```
 
 The location of the configuration file (config/instances.yaml) can be changes    

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -4,6 +4,7 @@ instances:
   bms1:
     provider: bms
     ip: 192.168.1.100
+    ssh_user: root
 contrail_configuration:
-  CONTAINER_REGISTRY: michaelhenkel
-  CONTRAIL_VERSION: ocata-5.0-20180219195722
+  CONTAINER_REGISTRY: opencontrailnightly
+  CONTRAIL_VERSION: latest

--- a/playbooks/roles/install_contrail/tasks/main.yml
+++ b/playbooks/roles/install_contrail/tasks/main.yml
@@ -220,7 +220,9 @@
 - name: add openstack controllers to the list
   set_fact:
     openstack_controller_list: "{{ openstack_controller_list + [ hostvars[item]['private_ip'] ] }}"
-  when: hostvars[item]['instance_data']['roles'].openstack is defined or hostvars[item]['instance_data']['roles'].openstack_control is defined
+  when:
+    - contrail_configuration.CLOUD_ORCHESTRATOR == 'openstack'
+    - hostvars[item]['instance_data']['roles'].openstack is defined or hostvars[item]['instance_data']['roles'].openstack_control is defined
   with_items: "{{ groups['container_hosts'] }}"
 
 - name: set KEYSTONE_AUTH_HOST


### PR DESCRIPTION
in order to build the first example 'config/instances.yaml' I had to make these edits. 
With this PR the following command successfully built a single node k8 cluster w/ contrail
```
ansible-playbook -e orchestrator=kubernetes -i inventory/ playbooks/install_contrail.yml
```
I also updated the README to reflect the fact that orchestrator=none doesn't actually work and in fact needs to be kubernetes, openstack, or possibly vcenter, but none def does not work.

If there is a different preferred way to relay this info as opposed to PR, just let me know