### PR TITLE
add check for vrouter_data to avoid failure on non-vrouter nodes

### DIFF
--- a/playbooks/roles/configure_instances/tasks/install_software.yml
+++ b/playbooks/roles/configure_instances/tasks/install_software.yml
@@ -6,8 +6,10 @@
 - name: set vrouter data
   set_fact:
     vrouter_data: "{{ hostvars[inventory_hostname].instance_data.roles.vrouter }}"
+  when: hostvars[inventory_hostname].instance_data.roles.vrouter is defined
 
 - debug: msg="{{ vrouter_data }}"
+  when: vrouter_data is defined
 
 - name: set provider data
   set_fact:
@@ -233,12 +235,12 @@
     path: "/etc/default/grub"
     line: 'GRUB_CMDLINE_LINUX_DEFAULT="nomdmonddf nomdmonisw intel_iommu=on"'
     insertbefore: BOF
-  when: (vrouter_data.sriov is defined and vrouter_data.sriov == true) and file_rc.stat.exists == true
+  when: (vrouter_data is defined and vrouter_data.sriov is defined and vrouter_data.sriov == true) and file_rc.stat.exists == true
 
 - name: execute update-grub/sys
   command: grub2-mkconfig -o /boot/grub2/grub.cfg
   register: gstat
-  when: (vrouter_data.sriov is defined and vrouter_data.sriov == true) and file_rc.stat.exists == true
+  when: (vrouter_data is defined and vrouter_data.sriov is defined and vrouter_data.sriov == true) and file_rc.stat.exists == true
 
 - name: restart server
   shell: sleep 2 && shutdown -r now "Ansible updates triggered"
@@ -246,12 +248,12 @@
   poll: 0
   become: true
   when: (upgrade_kernel is defined and upgrade_kernel.changed) or
-        (vrouter_data.sriov is defined and vrouter_data.sriov == true and gstat is defined and gstat.changed)
+        (vrouter_data is defined and vrouter_data.sriov is defined and vrouter_data.sriov == true and gstat is defined and gstat.changed)
 
 - name: wait for server to come back online
   wait_for_connection:
     delay: 30
     timeout: 2400
   when: (upgrade_kernel is defined and upgrade_kernel.changed) or
-        (vrouter_data.sriov is defined and vrouter_data.sriov == true and gstat is defined and gstat.changed)
+        (vrouter_data is defined and vrouter_data.sriov is defined and vrouter_data.sriov == true and gstat is defined and gstat.changed)
 


### PR DESCRIPTION
latest change breaks on non-vrouter nodes.