### PR TITLE
fix typo for Use host specific PHYSICAL_INTERFACE

### DIFF
--- a/playbooks/roles/create_openstack_config/tasks/host_params.yml
+++ b/playbooks/roles/create_openstack_config/tasks/host_params.yml
@@ -27,8 +27,8 @@
   with_items: ['openstack_control', 'openstack_network', 'openstack_compute', 'vrouter', 'openstack_monitoring', 'openstack_storage', 'openstack']
   when:
     - instance_data.roles is defined
-    - instance_data.roles.item is defined
-    - instance_data.roles.item is mapping()
+    - instance_data.roles[item] is defined
+    - instance_data.roles[item] is mapping()
     - instance_data.roles[item].PHYSICAL_INTERFACE is defined
     - host_internal_interface is not defined
 


### PR DESCRIPTION
Hi,
I found a problem that will skipped even if ”instance_data.roles [item]. PHYSICAL_INTERFACE” is set.

Below is my configuration.
```
instances:
  bms1:
    provider: bms
    ip: 172.27.116.93
    roles:
        config_database:
        config:
        control:
        analytics_database:
        analytics:
        webui:
        openstack_control:
        openstack_network:
        openstack_storage:
        openstack_monitoring:
        vrouter:
          PHYSICAL_INTERFACE: eth0
          VROUTER_GATEWAY: 192.168.120.1
        openstack_compute:
```

Result.
```
ansible-playbook -v -i inventory/ -e orchestrator=openstack playbooks/install_contrail.yml
=====
snip
=====
TASK [create_openstack_config : Use host specific PHYSICAL_INTERFACE] *****************************************************************************************************************************************************************************************
task path: /root/contrail-ansible-deployer/playbooks/roles/create_openstack_config/tasks/host_params.yml:29
Read vars_file '{{ hostvars['localhost'].config_file }}'
Read vars_file '{{ hostvars['localhost'].config_file }}'
skipping: [172.27.116.93] => (item=openstack_control)  => {
    "changed": false,
    "item": "openstack_control",
    "skip_reason": "Conditional result was False"
}
skipping: [172.27.116.93] => (item=openstack_network)  => {
    "changed": false,
    "item": "openstack_network",
    "skip_reason": "Conditional result was False"
}
skipping: [172.27.116.93] => (item=openstack_compute)  => {
    "changed": false,
    "item": "openstack_compute",
    "skip_reason": "Conditional result was False"
}
skipping: [172.27.116.93] => (item=vrouter)  => {
    "changed": false,
    "item": "vrouter",
    "skip_reason": "Conditional result was False"
}
skipping: [172.27.116.93] => (item=openstack_monitoring)  => {
    "changed": false,
    "item": "openstack_monitoring",
    "skip_reason": "Conditional result was False"
}
skipping: [172.27.116.93] => (item=openstack_storage)  => {
    "changed": false,
    "item": "openstack_storage",
    "skip_reason": "Conditional result was False"
}
skipping: [172.27.116.93] => (item=openstack)  => {
    "changed": false,
    "item": "openstack",
    "skip_reason": "Conditional result was False"
}
Read vars_file '{{ hostvars['localhost'].config_file }}'
```

The cause of this problem was in typo.
Please merge.
