### PR TITLE
"is defined" added

### DIFF
--- a/playbooks/roles/kvm/tasks/build_and_start_container_hosts.yml
+++ b/playbooks/roles/kvm/tasks/build_and_start_container_hosts.yml
@@ -211,7 +211,7 @@
     ansible_user: "{{ item.value.ssh_user|default(provider_config.kvm.ssh_user) }}"
     instance_name: "{{ item.key }}"
     privat_ip: "{{ item.value.ip }}"
-  when: (provider_config.kvm.ssh_pwd is defined or item.value.ssh_pwd) and
+  when: (provider_config.kvm.ssh_pwd is defined or item.value.ssh_pwd is defined) and
         (provider_config.kvm.ssh_user is defined or item.value.ssh_user is defined)
 
 - name: add container vm {{ container_vm_hostname }} to inventory when private key is defined


### PR DESCRIPTION
I was trying to follow [this wiki guide](https://github.com/Juniper/contrail-ansible-deployer/wiki/Deployment-Example:-Contrail-and-Kubernetes-and-Openstack). (Mentioned in #37 )

This step would fail because ansible couldn't parse it.
I made this change, and now this step doesn't fail.