### PR TITLE
Add support for token ca cert when joining to k8s cluster

### DIFF
--- a/playbooks/roles/k8s/tasks/configure_k8s_join_node.yml
+++ b/playbooks/roles/k8s/tasks/configure_k8s_join_node.yml
@@ -51,5 +51,7 @@
     msg: "master token: {{ hostvars[k8s_master_name].mastertoken }}"
 
 - name: join k8s cluster
-  shell: "kubeadm join --token {{ hostvars[k8s_master_name].mastertoken }} --discovery-token-unsafe-skip-ca-verification {{ k8s_master_ip }}:6443"
+  shell: "kubeadm join --token {{ hostvars[k8s_master_name].mastertoken }}
+         --discovery-token-ca-cert-hash sha256:{{ hostvars[k8s_master_name].token_ca_cert }}
+         {{ k8s_master_ip }}:6443"
   when: node_exists == false

--- a/playbooks/roles/k8s/tasks/configure_k8s_master_node.yml
+++ b/playbooks/roles/k8s/tasks/configure_k8s_master_node.yml
@@ -76,6 +76,15 @@
   set_fact:
     mastertoken: "{{ output.stdout }}"
 
+- name: Get token ca cert
+  shell: "openssl x509 -in /etc/kubernetes/pki/ca.crt -noout -pubkey |
+         openssl rsa -pubin -outform DER 2>/dev/null | sha256sum | cut -d' ' -f1"
+  register: output
+
+- name: Set token ca cert
+  set_fact:
+    token_ca_cert: "{{ output.stdout }}"
+
 - name: get nodes
   shell: kubectl get nodes -o yaml |grep "\- address:" |awk '{print $3}'
   register: nodes_list_output


### PR DESCRIPTION
So far token ca cert was not used with kubeadm join command (skip flag was used).
It's not recommended and may lead to security breach.

This commit utilize token ca cert as described in kubernetes documentation to provide
secure way of joining nodes ot cluster.